### PR TITLE
Add redirection to shipping after form submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Redirect to `/shipping` not made after profile completion.
-- Click on checkboxes label (save info and newsletter opt-in) didn't toggle the checkbox state.
+- Redirect to `/shipping` after profile completion.
+- Click on checkboxes label (save info and newsletter opt-in) to toggle the checkbox state.
 
 ## [0.1.0] - 2020-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Redirect to `/shipping` not made after profile completion.
+- Click on checkboxes label (save info and newsletter opt-in) didn't toggle the checkbox state.
 
 ## [0.1.0] - 2020-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Redirect to `/shipping` not made after profile completion.
 
 ## [0.1.0] - 2020-03-30
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     "react": "3.x"
   },
   "dependencies": {
+    "vtex.checkout-container": "0.x",
     "vtex.document-field": "0.x",
     "vtex.order-manager": "0.x",
     "vtex.order-profile": "0.x",

--- a/react/ProfileForm.tsx
+++ b/react/ProfileForm.tsx
@@ -323,8 +323,6 @@ const ProfileForm: React.FC = () => {
       ])
 
       if (profileUpdateSuccess && clientPreferencesUpdateSuccess) {
-        // should go to the next step. maybe call a function exposed
-        // in the checkout-container context
         history.push('/shipping')
       } else {
         setSubmitFailed(true)

--- a/react/ProfileForm.tsx
+++ b/react/ProfileForm.tsx
@@ -12,6 +12,7 @@ import { Input, Checkbox, Button, ButtonPlain, IconEdit } from 'vtex.styleguide'
 import { useRuntime } from 'vtex.render-runtime'
 import { PhoneField, PhoneContext, rules } from 'vtex.phone-field'
 import { DocumentField } from 'vtex.document-field'
+import { Router } from 'vtex.checkout-container'
 
 const messages = defineMessages({
   emailInfo: {
@@ -139,6 +140,7 @@ const ProfileForm: React.FC = () => {
   } = OrderProfile.useOrderProfile()
   const { navigate } = useRuntime()
   const intl = useIntl()
+  const history = Router.useHistory()
 
   const [loading, setLoading] = useState(false)
   const [submitFailed, setSubmitFailed] = useState(false)
@@ -323,6 +325,7 @@ const ProfileForm: React.FC = () => {
       if (profileUpdateSuccess && clientPreferencesUpdateSuccess) {
         // should go to the next step. maybe call a function exposed
         // in the checkout-container context
+        history.push('/shipping')
       } else {
         setSubmitFailed(true)
       }

--- a/react/ProfileForm.tsx
+++ b/react/ProfileForm.tsx
@@ -84,6 +84,7 @@ type ProfileAction = { field: keyof ProfileState } & (
       error: MessageDescriptor | undefined
     }
   | { type: 'blur' }
+  | { type: 'focus' }
 )
 
 const profileReducer = (
@@ -98,7 +99,6 @@ const profileReducer = (
         ...profile[field],
         value,
         isValid: isValid ?? profile[field].isValid,
-        blur: false,
       }
 
       return {
@@ -124,6 +124,12 @@ const profileReducer = (
           ...profile[field],
           blur: true,
         },
+      }
+    }
+    case 'focus': {
+      return {
+        ...profile,
+        [field]: { ...profile[field], focus: true },
       }
     }
     default: {
@@ -259,6 +265,13 @@ const ProfileForm: React.FC = () => {
     })
   }
 
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = evt => {
+    dispatch({
+      type: 'focus',
+      field: evt.target.name as keyof ProfileState,
+    })
+  }
+
   const handlePhoneBlur: React.FocusEventHandler<HTMLInputElement> = () => {
     // this timeout is needed because the phone field component focus
     // the listbox button after the change handler, so we need to wait
@@ -386,6 +399,7 @@ const ProfileForm: React.FC = () => {
               }
               onChange={handleChange}
               onBlur={handleBlur}
+              onFocus={handleFocus}
             />
           </div>
           <div className="w-100 mt6 mt0-ns ml0 ml5-ns">
@@ -401,6 +415,7 @@ const ProfileForm: React.FC = () => {
               }
               onChange={handleChange}
               onBlur={handleBlur}
+              onFocus={handleFocus}
             />
           </div>
         </div>
@@ -414,6 +429,7 @@ const ProfileForm: React.FC = () => {
                 name="phone"
                 onChange={handlePhoneChange}
                 onBlur={handlePhoneBlur}
+                onFocus={handleFocus}
                 errorMessage={
                   (profileData.phone.blur &&
                     !profileData.phone.isValid &&
@@ -437,6 +453,7 @@ const ProfileForm: React.FC = () => {
               }
               onChange={handleDocumentChange}
               onBlur={handleBlur}
+              onFocus={handleFocus}
             />
           </div>
         </div>

--- a/react/ProfileForm.tsx
+++ b/react/ProfileForm.tsx
@@ -443,6 +443,7 @@ const ProfileForm: React.FC = () => {
         <div className="mv7">
           {orderForm.userProfileId == null && (
             <Checkbox
+              id="save-personal-info"
               label={intl.formatMessage(messages.saveInfoLabel)}
               checked={persistInfo}
               onChange={handlePersistInfoChange}
@@ -450,6 +451,7 @@ const ProfileForm: React.FC = () => {
           )}
           <div className="mt6">
             <Checkbox
+              id="optin-newsletter"
               label={intl.formatMessage(messages.newsletterOptinLabel)}
               checked={optInNewsletter}
               onChange={handleOptinNewsletterChange}

--- a/react/package.json
+++ b/react/package.json
@@ -11,11 +11,12 @@
   "devDependencies": {
     "@types/node": "^13.9.0",
     "@types/react": "^16.9.23",
-    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container",
+    "vtex.document-field": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
     "vtex.order-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile",
     "vtex.phone-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.96.1/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.26/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^13.9.0",
     "@types/react": "^16.9.23",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container",
-    "vtex.document-field": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field",
+    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
     "vtex.order-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile",
     "vtex.phone-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -166,13 +166,17 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field":
-  version "0.1.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field#dc2b3ee50609ef7abb3ec997a547e14e34d0c61a"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container":
+  version "0.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container#5510b1ebb8bc8ae565371ee70149ceee5ce1e321"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager":
-  version "0.8.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager#99a926da2acbfe7612306be3648228cf3469ce45"
+"vtex.document-field@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field":
+  version "0.1.0"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field#a4bd391b32decdd02065a05b5791ccbc579951ae"
+
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
+  version "0.8.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
 
 "vtex.order-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile":
   version "0.2.0"
@@ -182,10 +186,10 @@ shallow-equal@^1.2.1:
   version "0.1.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field#20fca2aff9f63b034ce102bf9beff00d31111252"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.96.1/public/@types/vtex.render-runtime":
-  version "8.96.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.96.1/public/@types/vtex.render-runtime#fc1e4ef3d821b47e1f6fe6a9a6a0a2c5a6005526"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime":
+  version "8.102.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime#30940fe2d0b4ee20e6e4a46160936c7df7ae7d00"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.26/public/@types/vtex.styleguide":
-  version "9.112.26"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.26/public/@types/vtex.styleguide#89a1e5de4cca1e923590840b5229917719291b15"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide":
+  version "9.118.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide#40cbd9c99e0cd8477d32aafe243d39c0dfadeb42"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -170,9 +170,9 @@ shallow-equal@^1.2.1:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container#5510b1ebb8bc8ae565371ee70149ceee5ce1e321"
 
-"vtex.document-field@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field":
+"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field":
   version "0.1.0"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.document-field@0.1.0+build1589915957/public/@types/vtex.document-field#a4bd391b32decdd02065a05b5791ccbc579951ae"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field#dc2b3ee50609ef7abb3ec997a547e14e34d0c61a"
 
 "vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
   version "0.8.4"


### PR DESCRIPTION
#### What problem is this solving?

When we submitted the profile form, the user stayed in it as if nothing had happened. I initially implemented it like this because I was thinking in implementing some sort of "smart redirect" in a layer above (in the app `vtex.checkout-container`) so if the store didn't had the shipping step the user would be redirected to the payment, but this is fine for now.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#/profile).

Go to the profile step, fill your informations and click the button. After loading, you should be redirected to the shipping step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->