### PR TITLE
CHUI-67: Add logout button to profile summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Logout button in profile summary component.
 
 ## [0.2.0] - 2020-07-01
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
   "store/checkout-profile-email-info": "Fill info for",
+  "store/checkout-profile-logout-label": "Not you? Logout",
   "store/checkout-profile-first-name-label": "First name",
   "store/checkout-profile-last-name-label": "Last name",
   "store/checkout-profile-phone-label": "Phone number",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
   "store/checkout-profile-email-info": "Preencher informações para",
+  "store/checkout-profile-logout-label": "Não é você? Sair",
   "store/checkout-profile-first-name-label": "Nome",
   "store/checkout-profile-last-name-label": "Sobrenome",
   "store/checkout-profile-phone-label": "Número de telefone",

--- a/react/ProfileSummary.tsx
+++ b/react/ProfileSummary.tsx
@@ -26,6 +26,7 @@ const ProfileSummary: React.FC = () => {
           <div className="ml4">
             <ButtonPlain
               href={`${rootPath}/checkout/changeToAnonymousUser/${orderForm.id}`}
+              testId="profile-logout-button"
             >
               <FormattedMessage id="store/checkout-profile-logout-label" />
             </ButtonPlain>

--- a/react/ProfileSummary.tsx
+++ b/react/ProfileSummary.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { OrderForm } from 'vtex.order-manager'
+import { FormattedMessage } from 'react-intl'
+import { ButtonPlain } from 'vtex.styleguide'
+import { useRuntime } from 'vtex.render-runtime'
 
 const ProfileSummary: React.FC = () => {
+  const { rootPath = '' } = useRuntime()
   const { orderForm } = OrderForm.useOrderForm()
 
   if (!orderForm.clientProfileData) {
@@ -16,7 +20,18 @@ const ProfileSummary: React.FC = () => {
 
   return (
     <div className="flex flex-column c-muted-1">
-      {fullName && <span className="db mb4 lh-title">{fullName}</span>}
+      <div className="mb4 lh-title flex items-center">
+        {fullName && <span>{fullName}</span>}{' '}
+        {(!orderForm.canEditData || orderForm.loggedIn) && (
+          <div className="ml4">
+            <ButtonPlain
+              href={`${rootPath}/checkout/changeToAnonymousUser/${orderForm.id}`}
+            >
+              <FormattedMessage id="store/checkout-profile-logout-label" />
+            </ButtonPlain>
+          </div>
+        )}
+      </div>
       <span className="db lh-title">{email}</span>
     </div>
   )

--- a/react/package.json
+++ b/react/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "@types/node": "^13.9.0",
     "@types/react": "^16.9.23",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container",
-    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container",
+    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager",
     "vtex.order-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile",
-    "vtex.phone-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide"
+    "vtex.phone-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.4/public/@types/vtex.phone-field",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.106.0/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.121.0/public/@types/vtex.styleguide"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -245,30 +245,30 @@ tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container":
-  version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container#5510b1ebb8bc8ae565371ee70149ceee5ce1e321"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container":
+  version "0.4.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container#b021d3d4443a1372a224dac0fabb6280b2348e2a"
 
-"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field":
-  version "0.1.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field#dc2b3ee50609ef7abb3ec997a547e14e34d0c61a"
+"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
+  version "0.1.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field#222a1052f966f79209ee8ec998fcd43ecd7fbcce"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
-  version "0.8.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager":
+  version "0.8.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager#1f01414540d02e2ea7e41e73edaf431d407a9985"
 
 "vtex.order-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile":
   version "0.2.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.2.0/public/@types/vtex.order-profile#431a5f235862cf63db356424b46188fe713cf4ad"
 
-"vtex.phone-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field":
-  version "0.1.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.3/public/@types/vtex.phone-field#20fca2aff9f63b034ce102bf9beff00d31111252"
+"vtex.phone-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.4/public/@types/vtex.phone-field":
+  version "0.1.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.phone-field@0.1.4/public/@types/vtex.phone-field#4e12b49ddca62514101c9e8694804827ed06c338"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime":
-  version "8.102.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.102.0/public/@types/vtex.render-runtime#30940fe2d0b4ee20e6e4a46160936c7df7ae7d00"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.106.0/public/@types/vtex.render-runtime":
+  version "8.106.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.106.0/public/@types/vtex.render-runtime#545b27f0bb91d7387d45a27a807e06eac2f4908f"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide":
-  version "9.118.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.118.0/public/@types/vtex.styleguide#40cbd9c99e0cd8477d32aafe243d39c0dfadeb42"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.121.0/public/@types/vtex.styleguide":
+  version "9.121.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.121.0/public/@types/vtex.styleguide#acd5bb61dbbe2d5afff4ebd585015619300e6c92"


### PR DESCRIPTION
#### What problem is this solving?

Adds the button so the user can logout directly on Checkout.

#### How should this be manually tested?

[Workspace](https://sndpurchase--checkoutio.myvtex.com/).

Test plan:

1. Unauthenticated, identified:
   1. Enter in the above workspace, add an item to your cart.
   2. Proceed to Checkout, and enter a second purchase email (you can use `lucas.brito@vtex.com.br` if you want).
   3. In Checkout, click the "not you? logout" button and you should be redirected to the identification page.
2. Authenticated:
   1. Enter in the above workspace again, and log in into your account.
   2. Add an item to your cart.
   3. Proceed to Checkout.
   4. In Checkout, click in the "not you? logout" button, you should be redirected to the identification page and should not be logged in your account.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->